### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Zabbix loadable module for accessing and querying data on ZBUS telemetry bus"
 license-file = "LICENSE"
-homepage = "https://github.com/vulogov/zabbix_zbus_module"
+repository = "https://github.com/vulogov/zabbix_zbus_module"
 
 
 [lib]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.
